### PR TITLE
Remove message field if JSON successful

### DIFF
--- a/pipeline/logstash.conf
+++ b/pipeline/logstash.conf
@@ -43,10 +43,12 @@ filter {
     source => "message"
     target => "data"
     skip_on_invalid_json => true
+    remove_field => [ "message" ]
   }
 
   kv {
     target => "data"
+    remove_field => [ "message" ]
   }
 }
 


### PR DESCRIPTION
The idea is to stop the KV filter from overriding a potentially
successsful JSON parse.

When a message contains a URL with a query string it means it'll contain
an `=` which KV will pick up and attempt to parse.