### PR TITLE
support hypenated commands

### DIFF
--- a/pipeline/logstash.conf
+++ b/pipeline/logstash.conf
@@ -22,7 +22,7 @@ filter {
   grok {
     match => {
       "message" => [
-        "%{WORD:[@app][command]}:%{WORD:[@app][revision]}/%{WORD:container_id} %{GREEDYDATA:message}",
+        "%{NOTSPACE:[@app][command]}:%{WORD:[@app][revision]}/%{WORD:container_id} %{GREEDYDATA:message}",
         "agent\:%{GREEDYDATA:agent}/%{GREEDYDATA:instance_id} %{WORD:event_name} %{WORD:[@app][command]} process %{WORD:container_id}%{SPACE}(via %{WORD:signal}|due to %{WORD:reason})?",
         "\[%{TIMESTAMP_ISO8601:timestamp}%{DATA}\]%{SPACE}%{LOGLEVEL:loglevel} %{PROG:program} : %{GREEDYDATA:message}"
       ]


### PR DESCRIPTION
The WORD pattern strips the leading `reports` from `reports-worker`, making it hard to distinguish `reports-worker` from `comms-worker` in panoramix logs.